### PR TITLE
Add automatic update polling

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -860,4 +860,31 @@ function medmaster_ajax_edit_update() {
     wp_die();
 }
 add_action('wp_ajax_medmaster_edit_update', 'medmaster_ajax_edit_update');
+
+// AJAX check for new updates
+function medmaster_ajax_check_new_updates() {
+    check_ajax_referer('medmaster_ajax_nonce', 'nonce');
+
+    $after = isset($_POST['after']) ? sanitize_text_field($_POST['after']) : '';
+    if (empty($after)) {
+        wp_send_json_success(['has_new' => false]);
+        wp_die();
+    }
+
+    $args = [
+        'post_type'      => 'updates',
+        'posts_per_page' => 1,
+        'post_status'    => 'publish',
+        'date_query'     => [
+            ['after' => $after]
+        ]
+    ];
+
+    $query = new WP_Query($args);
+    $has_new = $query->have_posts();
+    wp_send_json_success(['has_new' => $has_new]);
+    wp_die();
+}
+add_action('wp_ajax_medmaster_check_new_updates', 'medmaster_ajax_check_new_updates');
+add_action('wp_ajax_nopriv_medmaster_check_new_updates', 'medmaster_ajax_check_new_updates');
 ?>

--- a/js/medmaster-scripts.js
+++ b/js/medmaster-scripts.js
@@ -334,4 +334,24 @@ jQuery(document).ready(function($) {
             });
         }
     });
+    function checkForNewUpdates() {
+        var latestDate = jQuery(".update-card-wrapper").first().data("update-date");
+        if (!latestDate) { return; }
+        jQuery.ajax({
+            url: medmaster_ajax.ajax_url,
+            type: "POST",
+            data: {
+                action: "medmaster_check_new_updates",
+                after: latestDate,
+                nonce: medmaster_ajax.nonce
+            },
+            success: function(response) {
+                if (response.success && response.data.has_new) {
+                    location.reload();
+                }
+            }
+        });
+    }
+    setInterval(checkForNewUpdates, 60000);
+
 });

--- a/page-templates/page-dashboard.php
+++ b/page-templates/page-dashboard.php
@@ -131,7 +131,7 @@ $is_admin = current_user_can('manage_options');
                         $excerpt = wp_trim_words(get_the_excerpt(), 30, '...');
                         $has_more = (strlen($content) > strlen($excerpt) + 20);
                 ?>
-                        <div class="col-md-12 mb-3 update-card-wrapper" data-update-id="<?php echo $update_id; ?>">
+                        <div class="col-md-12 mb-3 update-card-wrapper" data-update-id="<?php echo $update_id; ?>" data-update-date="<?php echo get_the_date('c'); ?>">
                             <div class="card">
                                 <div class="card-body">
                                     <h5 class="card-title d-flex justify-content-between">


### PR DESCRIPTION
## Summary
- add server endpoint `medmaster_check_new_updates`
- record update publish time in dashboard markup
- poll server every 60 seconds to reload when new updates exist

## Testing
- `php` unavailable, so PHP lint was skipped

------
https://chatgpt.com/codex/tasks/task_e_685d1c2543ec8322b02d1959789ba3af