### PR TITLE
Change default date in edit modal

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -780,7 +780,8 @@ function medmaster_ajax_get_update() {
         $tag_id = $tags[0]->term_id;
     }
     
-    $publish_date = date('Y-m-d', strtotime($post->post_date));
+    // Default the publish date to today's date when editing an update
+    $publish_date = current_time('Y-m-d');
     
     wp_send_json_success([
         'title' => $post->post_title,


### PR DESCRIPTION
## Summary
- default the publish date for editing updates to today's date

## Testing
- `php -l functions.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68611e7ca13c832287b7036a8604e078