### PR TITLE
Add status badges and correct edit date

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -780,8 +780,8 @@ function medmaster_ajax_get_update() {
         $tag_id = $tags[0]->term_id;
     }
     
-    // Default the publish date to today's date when editing an update
-    $publish_date = current_time('Y-m-d');
+    // Use the post's publish date when editing
+    $publish_date = date('Y-m-d', strtotime($post->post_date));
     
     wp_send_json_success([
         'title' => $post->post_title,

--- a/page-templates/page-dashboard.php
+++ b/page-templates/page-dashboard.php
@@ -151,9 +151,13 @@ $is_admin = current_user_can('manage_options');
                                         <?php echo $tag_html; ?>
                                         <span class="publish-date">
                                             <?php echo $publish_date; ?>
-                                            <?php if ($is_admin && $is_future_post) : ?>
-                                                <span class="badge bg-warning text-dark ms-1">מתוזמן (<?php echo get_the_date('d/m/Y H:i', $update_id); ?>)</span>
-                                            <?php endif; ?>
+                                            <span class="badge ms-1 <?php echo $is_future_post ? 'bg-warning text-dark' : 'bg-success'; ?>">
+                                                <?php if ($is_future_post) : ?>
+                                                    Scheduled (<?php echo get_the_date('d/m/Y H:i', $update_id); ?>)
+                                                <?php else : ?>
+                                                    Public
+                                                <?php endif; ?>
+                                            </span>
                                         </span>
                                     </p>
                                     <div class="card-text update-content">


### PR DESCRIPTION
## Summary
- show publish or scheduled badge on dashboard cards
- return the post's actual publish date when editing

## Testing
- `php -l functions.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863ccb0134483229865209dd8af18e0