### PR TITLE
Implement draft status for future-dated edits

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -828,7 +828,7 @@ function medmaster_ajax_edit_update() {
     if (!empty($publish_date)) {
         $publish_timestamp = strtotime($publish_date);
         $post_date = date('Y-m-d H:i:s', $publish_timestamp);
-        $post_status = ($publish_timestamp > current_time('timestamp')) ? 'future' : 'publish';
+        $post_status = ($publish_timestamp > current_time('timestamp')) ? 'draft' : 'publish';
     }
     
     $update_data = array(


### PR DESCRIPTION
## Summary
- ensure that editing a post with a future date reverts the post status to `draft`

## Testing
- `php -l functions.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863e729f2088322a9ace16943606bc8